### PR TITLE
SYNCP: Fix readdir. Set dh->filled to 0 by default.

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4018,7 +4018,6 @@ static int fill_dir(void *dh_, const char *name, const struct stat *statp,
 		if (extend_contents(dh, dh->needlen) == -1)
 			return 1;
 
-		dh->filled = 0;
 		newlen = dh->len +
 			fuse_add_direntry(dh->req, dh->contents + dh->len,
 					  dh->needlen - dh->len, name,
@@ -4026,6 +4025,7 @@ static int fill_dir(void *dh_, const char *name, const struct stat *statp,
 		if (newlen > dh->needlen)
 			return 1;
 	} else {
+		dh->filled = 1;
 		newlen = dh->len +
 			fuse_add_direntry(dh->req, NULL, 0, name, NULL, 0);
 		if (extend_contents(dh, newlen) == -1)
@@ -4055,7 +4055,7 @@ static int readdir_fill(struct fuse *f, fuse_req_t req, fuse_ino_t ino,
 		dh->len = 0;
 		dh->error = 0;
 		dh->needlen = size;
-		dh->filled = 1;
+		dh->filled = 0;
 		dh->req = req;
 		fuse_prepare_interrupt(f, req, &d);
 		err = fuse_fs_readdir(f->fs, path, dh, fill_dir, off, fi);


### PR DESCRIPTION
When there are two concurrent requests for directory listing, the one
that finishes first, will set dh->filled to 1 in its last empty call
to fill_dir, so the others will not perform readdir_fill() and return
incomplete listing.